### PR TITLE
Add cache invalidation method based on Doctrine events

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The Fix entity is configured with cache invalidation through a Doctrine EventSub
 This is pretty similar to the setup used in API Platform (see PurgeHttpCacheListener) and PurgerInterface method, with the difference that we're not operating on $iris, but on entity classes instead.
 Using this method, we don't need to transform from $iris back to classes, the reverse of which is done in PurgeHttpCacheListener.
 When a Fix is mutated, all of the cached responses related to the Fix (item and collections) are purged.
+We've also added a (simple, OneToOne) relation to the Fix, a FixRelation, to test handling relations in this approach.
+Currently we invalidate the cache for the collection of FixRelations when a Fix is updated.
 
 The DoctrineCacheInvalidationSubscriber is quite generic and no manual work is required to update the caching configuration.
 For the sake of the POC, the custom purger will only trigger on Fix entities, but it could be used to trigger on all kinds of entities.

--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ For the sake of this POC it has been implemented to only trigger on the Bug enti
 
 #### Fix
 
-The Fix entity is configured with cache invalidation through a Doctrine EventSubscriber.
+The Fix entity is configured with cache invalidation through a Doctrine Event Listener.
 This is pretty similar to the setup used in API Platform (see PurgeHttpCacheListener) and PurgerInterface method, with the difference that we're not operating on $iris, but on entity classes instead.
 Using this method, we don't need to transform from $iris back to classes, the reverse of which is done in PurgeHttpCacheListener.
 When a Fix is mutated, all of the cached responses related to the Fix (item and collections) are purged.
 We've also added a (simple, OneToOne) relation to the Fix, a FixRelation, to test handling relations in this approach.
 Currently we invalidate the cache for the collection of FixRelations when a Fix is updated.
+In addition to that, we've also included a OneToMany relation from FixGroup to Fix.
+The collection route for FixGroups is also invalidated using the CacheManager.
 
 The DoctrineCacheInvalidationSubscriber is quite generic and no manual work is required to update the caching configuration.
 For the sake of the POC, the custom purger will only trigger on Fix entities, but it could be used to trigger on all kinds of entities.
@@ -94,10 +96,10 @@ When the JWT is renewed, the responses in the cache will not be valid for the cl
 
 ## TODO / Improvements
 
-* Look into cache refresh
-* Look into integration with API Platform using PurgerInterface
+* Look into integration with API Platform using PurgerInterface.
 * What about pagination? Currently the full cache is purged; sounds reasonable to do, though.
 * What about warming up the request cache? In theory, we do know what the cached item should look like, but it might Vary...
-* Add UserContext and handling thereof in the cache
-* Add some custom commands for managing the HttpCache
-* Extend documentation with general HttpCache usage server as well as client side
+* Add UserContext and handling thereof in the cache.
+* Add some custom commands for managing the HttpCache.
+* Look into using tag-based approach to cache invalidation in combination with Symfony HttpCache.
+* Extend documentation with general HttpCache usage server as well as client side.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ If this is the case, the corresponding collection route for the entity is constr
 The CacheInvalidationSubscriber is quite generic and does not need manual rules to be added to the configuration.
 For the sake of this POC it has been implemented to only trigger on the Bug entity, but it could well be put to use to all entity types, depending on the application in use.
 
+This method does not take into account whether the mutating request actually mutates the entity; it's simply triggered upon performing the request.
+It also does not inspect the relations an entity may have.
+
 #### Fix
 
 The Fix entity is configured with cache invalidation through a Doctrine Event Listener.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ We've implemented each of the methods to be used with a specific Entity:
 * Issue (Rule-based)
 * Item (Tag-based)
 * Bug (Custom)
+* Fix (Doctrine Events)
 
 Each of those will be described in the following subsections.
 
@@ -71,6 +72,16 @@ If this is the case, the corresponding collection route for the entity is constr
 The CacheInvalidationSubscriber is quite generic and does not need manual rules to be added to the configuration.
 For the sake of this POC it has been implemented to only trigger on the Bug entity, but it could well be put to use to all entity types, depending on the application in use.
 
+#### Fix
+
+The Fix entity is configured with cache invalidation through a Doctrine EventSubscriber.
+This is pretty similar to the setup used in API Platform (see PurgeHttpCacheListener) and PurgerInterface method, with the difference that we're not operating on $iris, but on entity classes instead.
+Using this method, we don't need to transform from $iris back to classes, the reverse of which is done in PurgeHttpCacheListener.
+When a Fix is mutated, all of the cached responses related to the Fix (item and collections) are purged.
+
+The DoctrineCacheInvalidationSubscriber is quite generic and no manual work is required to update the caching configuration.
+For the sake of the POC, the custom purger will only trigger on Fix entities, but it could be used to trigger on all kinds of entities.
+
 ## Vary
 
 Currently configured for Vary are the Accept, Content-Type and Authorization headers.
@@ -83,6 +94,8 @@ When the JWT is renewed, the responses in the cache will not be valid for the cl
 
 * Look into cache refresh
 * Look into integration with API Platform using PurgerInterface
+* What about pagination? Currently the full cache is purged; sounds reasonable to do, though.
+* What about warming up the request cache? In theory, we do know what the cached item should look like, but it might Vary...
 * Add UserContext and handling thereof in the cache
 * Add some custom commands for managing the HttpCache
 * Extend documentation with general HttpCache usage server as well as client side

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -34,8 +34,8 @@ services:
     ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolver:
         alias: api_platform.route_name_resolver.cached.inner
 
-    App\Cache\DoctrineCacheInvalidationListener:
-        class: App\Cache\DoctrineCacheInvalidationListener
+    App\Cache\DoctrineCacheInvalidationUsingRouteNamesListener:
+        class: App\Cache\DoctrineCacheInvalidationUsingRouteNamesListener
         tags:
             - { name: doctrine.event_listener, event: preUpdate }
             - { name: doctrine.event_listener, event: onFlush }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,6 +29,9 @@ services:
     api_platform.http_cache.purger:
         class: App\Cache\Purger
 
+    ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolver:
+        alias: api_platform.route_name_resolver.cached.inner
+
     App\Cache\DoctrineCacheInvalidationListener:
         class: App\Cache\DoctrineCacheInvalidationListener
         tags:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,6 +26,8 @@ services:
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
 
+    'Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter': ~
+
     api_platform.http_cache.purger:
         class: App\Cache\Purger
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -35,4 +35,6 @@ services:
     App\Cache\DoctrineCacheInvalidationListener:
         class: App\Cache\DoctrineCacheInvalidationListener
         tags:
+            - { name: doctrine.event_listener, event: preUpdate }
             - { name: doctrine.event_listener, event: onFlush }
+            - { name: doctrine.event_listener, event: postFlush }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -28,3 +28,8 @@ services:
 
     api_platform.http_cache.purger:
         class: App\Cache\Purger
+
+    App\Cache\DoctrineCacheInvalidationListener:
+        class: App\Cache\DoctrineCacheInvalidationListener
+        tags:
+            - { name: doctrine.event_listener, event: onFlush }

--- a/src/Cache/DoctrineCacheInvalidationListener.php
+++ b/src/Cache/DoctrineCacheInvalidationListener.php
@@ -18,6 +18,7 @@ use ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolverInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\Exception\RuntimeException;
 use App\Entity\Fix;
+use App\Entity\FixRelation;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
@@ -172,6 +173,7 @@ class DoctrineCacheInvalidationListener
 
     private function addRoutesFor($value) : void
     {
+
         if (!$value) {
             return;
         }
@@ -195,7 +197,7 @@ class DoctrineCacheInvalidationListener
     {
         try {
             $class = ClassUtils::getClass($value);
-            if ($class !== Fix::class) {
+            if ($class !== Fix::class && $class !== FixRelation::class) {
                 return;
             }
 

--- a/src/Cache/DoctrineCacheInvalidationListener.php
+++ b/src/Cache/DoctrineCacheInvalidationListener.php
@@ -3,6 +3,10 @@
  * Author: Herman Slatman
  * Date: 2019-05-24
  * Time: 16:22
+ *
+ * NOTE: this file was heavily inspired on the PurgeHttpCacheListener in API Platform:
+ * https://github.com/api-platform/core/blob/44a686cd9c047520d809e0c529b368822e9bb948/src/Bridge/Doctrine/EventListener/PurgeHttpCacheListener.php
+ *
  */
 
 namespace App\Cache;
@@ -12,10 +16,15 @@ use ApiPlatform\Core\Api\OperationType;
 use ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolver;
 use ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolverInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
+use ApiPlatform\Core\Exception\RuntimeException;
 use App\Entity\Fix;
+use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\PersistentCollection;
 use FOS\HttpCacheBundle\CacheManager;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class DoctrineCacheInvalidationListener
 {
@@ -32,10 +41,29 @@ class DoctrineCacheInvalidationListener
     /** @var RouteNameResolverInterface $resolver */
     private $resolver;
 
+    /** @var \Symfony\Component\PropertyAccess\PropertyAccessor $property_accessor */
+    private $property_accessor;
+
     public function __construct(CacheManager $manager, RouteNameResolver $resolver)
     {
         $this->manager = $manager;
         $this->resolver = $resolver;
+        $this->property_accessor = PropertyAccess::createPropertyAccessor();
+    }
+
+    public function preUpdate(PreUpdateEventArgs $args): void
+    {
+        $object = $args->getObject();
+        $this->gatherResourceRoutes($object);
+        $change_set = $args->getEntityChangeSet();
+        $association_mappings = $args->getEntityManager()->getClassMetadata(ClassUtils::getClass($object))->getAssociationMappings();
+        foreach ($change_set as $key => $value) {
+            if (!isset($association_mappings[$key])) {
+                continue;
+            }
+            $this->addRoutesFor($value[0]);
+            $this->addRoutesFor($value[1]);
+        }
     }
 
     public function onFlush(OnFlushEventArgs $args) {
@@ -51,64 +79,108 @@ class DoctrineCacheInvalidationListener
         // something is handled within a service. Of course we could make this configurable in some way, though...
 
         // We also should always update collections/items when there are related entities
-        // TODO: we need to look into pagination of the result sets
 
         foreach ($uow->getScheduledEntityInsertions() as $entity) {
-            $this->gatherResourceAndItemClasses($entity, false);
-            $this->gatherRelationClasses($em, $entity);
+            // NOTE: including the entity insertions, because we might be running in a service, not in a request
+            $this->gatherResourceRoutes($entity);
+            $this->gatherRelationRoutes($em, $entity);
         }
         foreach ($uow->getScheduledEntityUpdates() as $entity) {
-            $this->gatherResourceAndItemClasses($entity, true);
-            $this->gatherRelationClasses($em, $entity);
+            $this->gatherResourceRoutes($entity);
+            $this->gatherRelationRoutes($em, $entity);
         }
         foreach ($uow->getScheduledEntityDeletions() as $entity) {
-            $this->gatherResourceAndItemClasses($entity, true);
-            $this->gatherRelationClasses($em, $entity);
-        }
-
-
-        foreach($this->collection_routes as $route) {
-            $this->manager->invalidateRoute($route);
-        }
-
-        foreach($this->item_routes as $item) {
-            $route = $item['route'];
-            $parameters = $item['parameters'];
-            $this->manager->invalidateRoute($route, $parameters);
+            $this->gatherResourceRoutes($entity);
+            $this->gatherRelationRoutes($em, $entity);
         }
 
     }
 
-    private function gatherResourceAndItemClasses($entity, bool $purgeItem): void
+    public function postFlush(): void
+    {
+        if (empty($this->collection_routes)) {
+            return;
+        }
+
+        $unique_collection_routes = array_unique($this->collection_routes);
+
+        foreach($unique_collection_routes as $route) {
+            $this->manager->invalidateRoute($route);
+        }
+
+        $this->collection_routes = [];
+
+    }
+
+    private function gatherResourceRoutes($entity): void
     {
 
         // TODO: filter doubles? i.e. the ones that are triggerd automatically by symfony/cache already?
 
         try {
-            if (\get_class($entity) !== Fix::class) {
+            $class = ClassUtils::getClass($entity);
+            if ($class !== Fix::class) {
                 return;
             }
-            $route = $this->resolver->getRouteName(Fix::class, OperationType::COLLECTION);
+
+            $route = $this->resolver->getRouteName($class, OperationType::COLLECTION);
             $this->collection_routes[] = $route;
-            if ($purgeItem) {
-                $route = $this->resolver->getRouteName(Fix::class, OperationType::ITEM);
-                $parameters = ['id' => $entity->getId()]; // TODO: assuming an id is set; can we do better?
-                $this->item_routes[] = ['route' => $route, 'parameters' => $parameters];
-            }
+
         } catch (InvalidArgumentException $e) {
             return;
         }
     }
 
-    private function gatherRelationClasses(EntityManagerInterface $em, $entity): void
+    private function gatherRelationRoutes(EntityManagerInterface $em, $entity): void
     {
-        if (\get_class($entity) !== Fix::class) {
+        $class = ClassUtils::getClass($entity);
+        if ($class !== Fix::class) {
             return;
         }
-//        $associationMappings = $em->getClassMetadata(ClassUtils::getClass($entity))->getAssociationMappings();
-//        foreach (array_keys($associationMappings) as $property) {
-//            $this->addTagsFor($this->propertyAccessor->getValue($entity, $property));
-//        }
+
+        $association_mappings = $em->getClassMetadata($class)->getAssociationMappings();
+        foreach (array_keys($association_mappings) as $property) {
+            $this->addRoutesFor($this->property_accessor->getValue($entity, $property));
+        }
     }
 
+    private function addRoutesFor($value) : void
+    {
+        if (!$value) {
+            return;
+        }
+
+        if (!is_iterable($value)) {
+            $this->addTagForItem($value);
+            return;
+        }
+
+        if ($value instanceof PersistentCollection) {
+            $value = clone $value;
+        }
+
+        foreach ($value as $v) {
+            $this->addTagForItem($v);
+        }
+
+    }
+
+    private function addTagForItem($value): void
+    {
+        try {
+            $class = ClassUtils::getClass($value);
+            if ($class !== Fix::class) {
+                return;
+            }
+
+            $route = $this->resolver->getRouteName($class, OperationType::COLLECTION);
+            $this->collection_routes[] = $route;
+
+        } catch (InvalidArgumentException $e) {
+
+        } catch (RuntimeException $e) {
+
+        }
+
+    }
 }

--- a/src/Cache/DoctrineCacheInvalidationListener.php
+++ b/src/Cache/DoctrineCacheInvalidationListener.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Author: Herman Slatman
+ * Date: 2019-05-24
+ * Time: 16:22
+ */
+
+namespace App\Cache;
+
+
+use ApiPlatform\Core\Exception\InvalidArgumentException;
+use App\Entity\Fix;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+use FOS\HttpCacheBundle\CacheManager;
+
+class DoctrineCacheInvalidationListener
+{
+    /** @var string[] $collection_classes */
+    private $collection_classes = [];
+
+    /** @var string[] $item_classes */
+    private $item_classes = [];
+
+    /** @var CacheManager $manager */
+    private $manager;
+
+    public function __construct(CacheManager $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    public function onFlush(OnFlushEventArgs $args) {
+        // TODO: gather the entity types; filter out for the sake of the POC
+        $em = $args->getEntityManager();
+        $uow = $em->getUnitOfWork();
+
+        // NOTE: we don't need to purge an item on insertion; only new item created.
+        // We don't need to purge the collection when an item is added, because FOSHttpCache already manages that.
+        // We do need to purge the collection when an entity is updated or deleted, though.
+
+        // On second thought, perhaps it's better to always purge, because we need to update too when
+        // something is handled within a service. Of course we could make this configurable in some way, though...
+
+        foreach ($uow->getScheduledEntityInsertions() as $entity) {
+            $this->gatherResourceAndItemClasses($entity, false);
+            $this->gatherRelationClasses($em, $entity);
+        }
+        foreach ($uow->getScheduledEntityUpdates() as $entity) {
+            $this->gatherResourceAndItemClasses($entity, true);
+            $this->gatherRelationClasses($em, $entity);
+        }
+        foreach ($uow->getScheduledEntityDeletions() as $entity) {
+            $this->gatherResourceAndItemClasses($entity, true);
+            $this->gatherRelationClasses($em, $entity);
+        }
+
+        //        if (\in_array(Fix::class, $this->collection_classes, true)) {
+//            dump($this->collection_classes);
+//            dd($this->item_classes);
+//        }
+//
+//        $name = 'TODO';
+//        //$this->manager->invalidateRoute($name);
+    }
+
+    private function gatherResourceAndItemClasses($entity, bool $purgeItem): void
+    {
+        try {
+            $class = \get_class($entity);
+            // TODO: create the right route to purge.
+            $this->collection_classes[] = $class;
+            if ($purgeItem) {
+                // TODO: create the right route to purge.
+                $this->item_classes[] = $class;
+            }
+        } catch (InvalidArgumentException $e) {
+            return;
+        }
+    }
+
+    private function gatherRelationClasses(EntityManagerInterface $em, $entity): void
+    {
+//        $associationMappings = $em->getClassMetadata(ClassUtils::getClass($entity))->getAssociationMappings();
+//        foreach (array_keys($associationMappings) as $property) {
+//            $this->addTagsFor($this->propertyAccessor->getValue($entity, $property));
+//        }
+    }
+
+}

--- a/src/Entity/Fix.php
+++ b/src/Entity/Fix.php
@@ -23,6 +23,11 @@ class Fix
      */
     private $description;
 
+    /**
+     * @ORM\OneToOne(targetEntity="App\Entity\FixRelation", cascade={"persist", "remove"})
+     */
+    private $relation;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -36,6 +41,18 @@ class Fix
     public function setDescription(string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+
+    public function getRelation(): ?FixRelation
+    {
+        return $this->relation;
+    }
+
+    public function setRelation(?FixRelation $relation): self
+    {
+        $this->relation = $relation;
 
         return $this;
     }

--- a/src/Entity/Fix.php
+++ b/src/Entity/Fix.php
@@ -26,7 +26,12 @@ class Fix
     /**
      * @ORM\OneToOne(targetEntity="App\Entity\FixRelation", cascade={"persist", "remove"})
      */
-    private $relation;
+    private $fix_relation;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="FixGroup", inversedBy="Fix")
+     */
+    private $fix_group;
 
     public function getId(): ?int
     {
@@ -45,14 +50,26 @@ class Fix
         return $this;
     }
 
-    public function getRelation(): ?FixRelation
+    public function getFixRelation(): ?FixRelation
     {
-        return $this->relation;
+        return $this->fix_relation;
     }
 
-    public function setRelation(?FixRelation $relation): self
+    public function setFixRelation(?FixRelation $fix_relation): self
     {
-        $this->relation = $relation;
+        $this->fix_relation = $fix_relation;
+
+        return $this;
+    }
+
+    public function getFixGroup(): ?FixGroup
+    {
+        return $this->fix_group;
+    }
+
+    public function setFixGroup(?FixGroup $fix_group): self
+    {
+        $this->fix_group = $fix_group;
 
         return $this;
     }

--- a/src/Entity/Fix.php
+++ b/src/Entity/Fix.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource()
+ * @ORM\Entity(repositoryClass="App\Repository\FixRepository")
+ */
+class Fix
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private $description;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+}

--- a/src/Entity/FixGroup.php
+++ b/src/Entity/FixGroup.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource()
+ * @ORM\Entity(repositoryClass="App\Repository\FixGroupRepository")
+ */
+class FixGroup
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private $name;
+
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\Fix", mappedBy="fix_group")
+     */
+    private $fixes;
+
+    public function __construct()
+    {
+        $this->fixes = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Fix[]
+     */
+    public function getFix(): Collection
+    {
+        return $this->fixes;
+    }
+
+    public function addFix(Fix $fix): self
+    {
+        if (!$this->fixes->contains($fix)) {
+            $this->fixes[] = $fix;
+            $fix->setFixGroup($this);
+        }
+
+        return $this;
+    }
+
+    public function removeFix(Fix $fix): self
+    {
+        if ($this->fixes->contains($fix)) {
+            $this->fixes->removeElement($fix);
+            // set the owning side to null (unless already changed)
+            if ($fix->getFixGroup() === $this) {
+                $fix->setFixGroup(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/src/Entity/FixRelation.php
+++ b/src/Entity/FixRelation.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource()
+ * @ORM\Entity(repositoryClass="App\Repository\FixRelationRepository")
+ */
+class FixRelation
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private $name;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/src/Repository/FixGroupRepository.php
+++ b/src/Repository/FixGroupRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\FixGroup;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+/**
+ * @method FixGroup|null find($id, $lockMode = null, $lockVersion = null)
+ * @method FixGroup|null findOneBy(array $criteria, array $orderBy = null)
+ * @method FixGroup[]    findAll()
+ * @method FixGroup[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class FixGroupRepository extends ServiceEntityRepository
+{
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, FixGroup::class);
+    }
+
+}

--- a/src/Repository/FixRelationRepository.php
+++ b/src/Repository/FixRelationRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\FixRelation;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+/**
+ * @method FixRelation|null find($id, $lockMode = null, $lockVersion = null)
+ * @method FixRelation|null findOneBy(array $criteria, array $orderBy = null)
+ * @method FixRelation[]    findAll()
+ * @method FixRelation[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class FixRelationRepository extends ServiceEntityRepository
+{
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, FixRelation::class);
+    }
+
+}

--- a/src/Repository/FixRepository.php
+++ b/src/Repository/FixRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Fix;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+/**
+ * @method Fix|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Fix|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Fix[]    findAll()
+ * @method Fix[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class FixRepository extends ServiceEntityRepository
+{
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, Fix::class);
+    }
+
+}


### PR DESCRIPTION
This PR adds a cache invalidation method based on Doctrine Lifecycle Events. 

By listening to events dispatched by Doctrine when entities are inserted, updated or deleted, we trigger cache invalidation through the FOSHttpCache CacheManager implementation. We also take relations into account to a certain extent. 

The implementation is heavily based on the PurgeHttpCacheListener approach used in API Platform. The main difference is we're using the CacheManager instead of cache tags. 

